### PR TITLE
Custom dropdown

### DIFF
--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -55,6 +55,7 @@ export default class Dropdown extends PureComponent {
     textColor: 'rgba(0, 0, 0, .87)',
     itemColor: 'rgba(0, 0, 0, .54)',
     baseColor: 'rgba(0, 0, 0, .38)',
+    dropdownBackgroundColor: 'rgba(255, 255, 255)'
 
     itemCount: 4,
     itemPadding: 8,
@@ -106,6 +107,7 @@ export default class Dropdown extends PureComponent {
     itemColor: PropTypes.string,
     selectedItemColor: PropTypes.string,
     baseColor: PropTypes.string,
+    dropdownBackgroundColor: PropTypes.string
 
     itemTextStyle: Text.propTypes.style,
 
@@ -530,6 +532,7 @@ export default class Dropdown extends PureComponent {
       renderAccessory,
       containerStyle,
       pickerStyle: pickerStyleOverrides,
+      dropdownBackgroundColor,
 
       rippleInsets,
       rippleOpacity,
@@ -553,6 +556,7 @@ export default class Dropdown extends PureComponent {
       itemPadding,
       dropdownPosition,
       animationDuration,
+      dropdownBackgroundColor,
     } = props;
 
     let { left, top, width, opacity, selected, modal } = this.state;
@@ -605,6 +609,27 @@ export default class Dropdown extends PureComponent {
       transform: [{ translateY }],
     };
 
+    let picker = {
+      // backgroundColor: 'rgb(255, 255, 255)',
+      backgroundColor: dropdownBackgroundColor,
+      borderRadius: 2,
+
+      position: 'absolute',
+
+      ...Platform.select({
+        ios: {
+          shadowRadius: 2,
+          shadowColor: 'rgba(0, 0, 0, 1.0)',
+          shadowOpacity: 0.54,
+          shadowOffset: { width: 0, height: 2 },
+        },
+
+        android: {
+          elevation: 2,
+        },
+      }),
+    }
+
     let { bottom, ...insets } = this.rippleInsets();
     let rippleStyle = {
       ...insets,
@@ -646,7 +671,7 @@ export default class Dropdown extends PureComponent {
           <TouchableWithoutFeedback onPress={this.onClose}>
             <View style={overlayStyle}>
               <Animated.View
-                style={[styles.picker, pickerStyle, pickerStyleOverrides]}
+                style={[picker, pickerStyle, pickerStyleOverrides]}
               >
                 <ScrollView
                   ref={this.updateScrollRef}

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -55,11 +55,7 @@ export default class Dropdown extends PureComponent {
     textColor: 'rgba(0, 0, 0, .87)',
     itemColor: 'rgba(0, 0, 0, .54)',
     baseColor: 'rgba(0, 0, 0, .38)',
-<<<<<<< HEAD
     dropdownBackgroundColor: 'rgba(255, 255, 255, .00)',
-=======
-    dropdownBackgroundColor: 'rgba(255, 255, 255)',
->>>>>>> f46b6f938216dc07a74be640de70342c5a97379c
 
     itemCount: 4,
     itemPadding: 8,

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -55,7 +55,7 @@ export default class Dropdown extends PureComponent {
     textColor: 'rgba(0, 0, 0, .87)',
     itemColor: 'rgba(0, 0, 0, .54)',
     baseColor: 'rgba(0, 0, 0, .38)',
-    dropdownBackgroundColor: 'rgba(255, 255, 255)'
+    dropdownBackgroundColor: 'rgba(255, 255, 255, .00)',
 
     itemCount: 4,
     itemPadding: 8,
@@ -107,7 +107,7 @@ export default class Dropdown extends PureComponent {
     itemColor: PropTypes.string,
     selectedItemColor: PropTypes.string,
     baseColor: PropTypes.string,
-    dropdownBackgroundColor: PropTypes.string
+    dropdownBackgroundColor: PropTypes.string,
 
     itemTextStyle: Text.propTypes.style,
 
@@ -555,8 +555,7 @@ export default class Dropdown extends PureComponent {
       baseColor,
       itemPadding,
       dropdownPosition,
-      animationDuration,
-      dropdownBackgroundColor,
+      animationDuration
     } = props;
 
     let { left, top, width, opacity, selected, modal } = this.state;
@@ -610,7 +609,6 @@ export default class Dropdown extends PureComponent {
     };
 
     let picker = {
-      // backgroundColor: 'rgb(255, 255, 255)',
       backgroundColor: dropdownBackgroundColor,
       borderRadius: 2,
 

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -446,6 +446,7 @@ export default class Dropdown extends PureComponent {
         editable={false}
         onChangeText={undefined}
         renderAccessory={renderAccessory}
+        lineWidth={0}
       />
     );
   }

--- a/src/components/dropdown/index.js
+++ b/src/components/dropdown/index.js
@@ -55,7 +55,7 @@ export default class Dropdown extends PureComponent {
     textColor: 'rgba(0, 0, 0, .87)',
     itemColor: 'rgba(0, 0, 0, .54)',
     baseColor: 'rgba(0, 0, 0, .38)',
-    dropdownBackgroundColor: 'rgba(255, 255, 255)'
+    dropdownBackgroundColor: 'rgba(255, 255, 255)',
 
     itemCount: 4,
     itemPadding: 8,

--- a/src/components/dropdown/styles.js
+++ b/src/components/dropdown/styles.js
@@ -27,27 +27,6 @@ export default StyleSheet.create({
     backgroundColor: 'transparent', /* XXX: Required */
   },
 
-  picker: {
-    // backgroundColor: 'rgb(255, 255, 255)',
-    backgroundColor: 'rgb(0,0,0)',
-    borderRadius: 2,
-
-    position: 'absolute',
-
-    ...Platform.select({
-      ios: {
-        shadowRadius: 2,
-        shadowColor: 'rgba(0, 0, 0, 1.0)',
-        shadowOpacity: 0.54,
-        shadowOffset: { width: 0, height: 2 },
-      },
-
-      android: {
-        elevation: 2,
-      },
-    }),
-  },
-
   item: {
     textAlign: 'left',
   },

--- a/src/components/dropdown/styles.js
+++ b/src/components/dropdown/styles.js
@@ -28,7 +28,8 @@ export default StyleSheet.create({
   },
 
   picker: {
-    backgroundColor: 'rgb(255, 255, 255)',
+    // backgroundColor: 'rgb(255, 255, 255)',
+    backgroundColor: 'rgb(0,0,0)',
     borderRadius: 2,
 
     position: 'absolute',


### PR DESCRIPTION
Added new prop dropdownBackgroundColor to set the dropdown's background.
react-native-material-dropdown renders a textfield as the base for the Ripple component, set the textfield prop lineWidth=0 so there's no bottom border.